### PR TITLE
Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker-compose up
 Goto [http://localhost:3030/d/o9mIe_Aik/internet-connection](http://localhost:3030/d/o9mIe_Aik/internet-connection) (change `localhost` to your docker host ip/name).
 
 ## Configuration
-To change what hosts you ping you change the `targets` section in [/prometheus/pinghosts.yml](./prometheus/pinghosts.yml) file.
+To change what hosts you ping you change the `targets` section in [/prometheus/pinghosts.yaml](./prometheus/pinghosts.yaml) file.
 
 For speedtest the only relevant configuration is how often you want the check to happen. It is at 5 minutes by default which might be too much if you have limit on downloads. This is changed by editing `scrape_interval` under `speedtest` in [/prometheus/prometheus.yml](./prometheus/prometheus.yml).
 


### PR DESCRIPTION
In configuration section link points to [/prometheus/pinghosts.yml] and url throws 404 error.  Correct url is (./prometheus/pinghosts.yaml)